### PR TITLE
Add structured DID auth proofs and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,16 @@ SDID 是一个 Chrome 浏览器扩展，帮助团队在无密码或通行密钥�
 - **Role-aware metadata｜角色与标签元数据** – capture roles, domains, tags, and notes to describe responsibilities or access boundaries. / 记录角色、域名、标签和备注，清晰表达权限范围与使用说明。
 - **Secure storage & backup｜安全存储与备份** – all identity data (including keys) lives in encrypted Chrome sync storage with JSON import/export support. / 身份数据（包含密钥）保存在受加密保护的 Chrome 同步存储中，并支持 JSON 导入导出备份。
 - **Autofill fallback｜表单自动填充备援** – keep optional usernames/passwords for legacy systems and inject them into the current tab in one click. / 可为传统系统保存备用用户名与密码，并在当前页面一键填充。
+- **Verifiable DID auth proofs｜可验证的 DID 授权凭证** – login responses ship with a canonicalized payload and W3C-style proof so relying parties can audit who signed what. / 登录响应附带经过规范化的负载与 W3C 风格的证明对象，方便接入方验证签名者与签名内容。
 - **Language toggle｜语言切换** – switch between English and Chinese across the popup, options page, and approval overlays with a single tap. / 弹窗、选项页与确认覆盖层均可一键切换中英文，界面即时更新。
 - **Minimal interface｜纯色线条界面** – refreshed visual styling inspired by Google/Apple design language: light surfaces, clean lines, and focused typography. / 参考 Google 与 Apple 的设计语言，界面以纯色与线条为主，排版更简洁、层次更清晰。
 - **Demo dApp｜演示应用** – the `/demo` folder hosts a ready-to-run site that requests SDID login and verifies the returned signature. / `/demo` 目录提供可直接运行的站点，用于发起 SDID 登录并验证返回的签名。
 
 ## Quick confirm login workflow｜快捷确认登录流程
 
-Web apps can call SDID from the page context and receive a streamlined confirmation dialog that mirrors popular wallet-to-dapp experiences. The sheet lets the user pick an identity, review roles and DID details, and optionally remember the requesting origin. Once confirmed, SDID signs the provided challenge with the identity’s private key, returns sanitized metadata plus the signature, and (when possible) fills matching username/password fields automatically.
+Web apps can call SDID from the page context and receive a streamlined confirmation dialog that mirrors popular wallet-to-dapp experiences. The sheet lets the user pick an identity, review roles and DID details, and optionally remember the requesting origin. Once confirmed, SDID produces a canonical authentication payload, signs it with the identity’s private key, attaches a W3C-style proof object, and (when possible) fills matching username/password fields automatically.
 
-网页应用可以直接在页面上下文中调用 SDID，并获得与常见钱包连接类似的快速确认体验。弹窗会展示身份名称、角色与 DID 详情，用户可选择记住当前站点。确认后，SDID 会使用该身份的私钥为挑战消息签名，并返回经过处理的身份信息与签名，同时在检测到用户名或密码输入框时自动填充。
+网页应用可以直接在页面上下文中调用 SDID，并获得与常见钱包连接类似的快速确认体验。弹窗会展示身份名称、角色与 DID 详情，用户可选择记住当前站点。确认后，SDID 会生成经过规范化的认证负载，用该身份的私钥签名并附上符合 W3C 规范的证明对象，同时在检测到用户名或密码输入框时自动填充。
 
 ### Requesting a login from a web app｜在网页应用中发起登录请求
 
@@ -37,7 +38,11 @@ Web apps can call SDID from the page context and receive a streamlined confirmat
         challenge,
       });
       console.log('SDID identity granted', response.identity);
-      console.log('Signature', response.signature);
+      console.log('Proof metadata', response.proof);
+
+      const canonicalRequest = response.authentication?.canonicalRequest || response.challenge;
+      console.log('Canonical payload', response.authentication?.payload);
+      // If you need to re-create the canonical string, reuse the JSON canonicalization logic from the extension.
 
       const publicKey = await crypto.subtle.importKey(
         'jwk',
@@ -51,7 +56,7 @@ Web apps can call SDID from the page context and receive a streamlined confirmat
         { name: 'ECDSA', hash: { name: 'SHA-256' } },
         publicKey,
         signatureBytes,
-        new TextEncoder().encode(response.challenge)
+        new TextEncoder().encode(canonicalRequest)
       );
       console.log('Signature verified?', verified);
       // response.fill contains autofill status for traditional login forms

--- a/demo/app.js
+++ b/demo/app.js
@@ -50,7 +50,8 @@ const translations = {
       missing: 'Missing public key or signature.',
       success: 'Signature verified successfully.',
       failure: 'Signature verification failed.',
-      error: 'Unable to verify the signature. Check the console for details.'
+      error: 'Unable to verify the signature. Check the console for details.',
+      mismatch: 'Authentication payload mismatch.'
     },
     login: {
       message: 'Demo dApp requests access'
@@ -98,7 +99,8 @@ const translations = {
       missing: '缺少公钥或签名。',
       success: '签名验证通过。',
       failure: '签名验证失败。',
-      error: '无法验证签名，请查看控制台日志。'
+      error: '无法验证签名，请查看控制台日志。',
+      mismatch: '认证负载不一致。'
     },
     login: {
       message: '演示应用请求访问'
@@ -141,6 +143,22 @@ function formatTemplate(template, replacements = {}) {
   return template.replace(/\{(\w+)\}/g, (match, token) => {
     return token in replacements ? String(replacements[token]) : match;
   });
+}
+
+function canonicalizeJson(value) {
+  if (value === null || value === undefined) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalizeJson(item)).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    const keys = Object.keys(value)
+      .filter((key) => value[key] !== undefined)
+      .sort();
+    return `{${keys.map((key) => `${JSON.stringify(key)}:${canonicalizeJson(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
 }
 
 function translate(key, replacements = {}, language = currentLanguage) {
@@ -258,9 +276,12 @@ function formatIdentityPayload(response) {
     challenge: response.challenge,
     signature: response.signature,
     algorithm: response.algorithm,
+    proof: response.proof,
+    authentication: response.authentication,
     authorized: response.authorized,
     remembered: response.remembered,
-    fill: response.fill
+    fill: response.fill,
+    requestId: response.requestId
   };
   return JSON.stringify(payload, null, 2);
 }
@@ -305,25 +326,53 @@ function createChallenge() {
   return `demo:${Date.now().toString(16)}:${crypto.getRandomValues(new Uint32Array(1))[0].toString(16)}`;
 }
 
-async function verifySignature(identity, challenge, signature) {
-  if (!identity?.publicKeyJwk || !signature || !challenge) {
+async function verifySignatureWithKey(publicKeyJwk, data, signature) {
+  const publicKey = await crypto.subtle.importKey(
+    'jwk',
+    publicKeyJwk,
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    false,
+    ['verify']
+  );
+  const binary = atob(signature);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  const dataBytes = new TextEncoder().encode(data);
+  return crypto.subtle.verify({ name: 'ECDSA', hash: { name: 'SHA-256' } }, publicKey, bytes, dataBytes);
+}
+
+async function verifyAuthenticationResponse(response) {
+  const identity = response?.identity;
+  if (!identity?.publicKeyJwk) {
     return { verified: false, key: 'verification.missing' };
   }
-  try {
-    const publicKey = await crypto.subtle.importKey(
-      'jwk',
-      identity.publicKeyJwk,
-      { name: 'ECDSA', namedCurve: 'P-256' },
-      false,
-      ['verify']
-    );
-    const binary = atob(signature);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i += 1) {
-      bytes[i] = binary.charCodeAt(i);
+
+  const signature = response?.proof?.signatureValue || response?.signature;
+  const canonicalRequest = typeof response?.authentication?.canonicalRequest === 'string'
+    ? response.authentication.canonicalRequest
+    : null;
+  const payload = response?.authentication?.payload || null;
+
+  let dataToVerify = canonicalRequest;
+  if (payload && canonicalRequest) {
+    const reconstructed = canonicalizeJson(payload);
+    if (reconstructed !== canonicalRequest) {
+      return { verified: false, key: 'verification.mismatch' };
     }
-    const data = new TextEncoder().encode(challenge);
-    const verified = await crypto.subtle.verify({ name: 'ECDSA', hash: { name: 'SHA-256' } }, publicKey, bytes, data);
+  }
+
+  if (!dataToVerify) {
+    dataToVerify = response?.challenge || null;
+  }
+
+  if (!signature || !dataToVerify) {
+    return { verified: false, key: 'verification.missing' };
+  }
+
+  try {
+    const verified = await verifySignatureWithKey(identity.publicKeyJwk, dataToVerify, signature);
     return { verified, key: verified ? 'verification.success' : 'verification.failure' };
   } catch (error) {
     console.error('Signature verification error', error);
@@ -365,7 +414,7 @@ function changeLanguage(language) {
   applyVerification();
 }
 
-async function requestLogin(forcePrompt = false) {
+async function requestLogin(forcePrompt = true) {
   disableButtons(true);
   setVerification(null);
   renderIdentity(null);
@@ -379,7 +428,7 @@ async function requestLogin(forcePrompt = false) {
       forcePrompt
     });
     renderIdentity(response);
-    const verification = await verifySignature(response.identity, response.challenge, response.signature);
+    const verification = await verifyAuthenticationResponse(response);
     setVerification(verification);
     const label = (response.identity?.label && response.identity.label.trim())
       || response.identity?.did
@@ -422,7 +471,7 @@ if (languageButtons.length) {
 }
 
 if (connectButton) {
-  connectButton.addEventListener('click', () => requestLogin(false));
+  connectButton.addEventListener('click', () => requestLogin());
 }
 
 if (forceButton) {

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -66,6 +66,31 @@ function safeParseJson(value) {
   }
 }
 
+function getVerificationMethodId(identity) {
+  if (!identity?.did) {
+    return '';
+  }
+  return `${identity.did}#keys-1`;
+}
+
+function formatKeyType(publicKeyJwk) {
+  if (!publicKeyJwk || typeof publicKeyJwk !== 'object') {
+    return '';
+  }
+  const parts = [];
+  if (publicKeyJwk.crv) {
+    parts.push(publicKeyJwk.crv);
+  }
+  if (publicKeyJwk.kty) {
+    parts.push(publicKeyJwk.kty);
+  }
+  const base = parts.join(' / ');
+  if (publicKeyJwk.alg) {
+    return base ? `${base} (${publicKeyJwk.alg})` : publicKeyJwk.alg;
+  }
+  return base;
+}
+
 function normalizeKeyPair(raw) {
   if (!raw) {
     return null;
@@ -243,6 +268,23 @@ function renderCollection() {
       const didLine = document.createElement('span');
       didLine.textContent = `${translate('options.collection.meta.did')} ${identity.did}`;
       meta.appendChild(didLine);
+    }
+
+    if (identity.did && identity.publicKeyJwk) {
+      const verificationLine = document.createElement('span');
+      verificationLine.textContent = `${translate('options.collection.meta.verificationMethod')} ${getVerificationMethodId(
+        identity
+      )}`;
+      meta.appendChild(verificationLine);
+    }
+
+    if (identity.publicKeyJwk) {
+      const keyType = formatKeyType(identity.publicKeyJwk);
+      if (keyType) {
+        const keyLine = document.createElement('span');
+        keyLine.textContent = `${translate('options.collection.meta.keyType')} ${keyType}`;
+        meta.appendChild(keyLine);
+      }
     }
 
     if (identity.username) {

--- a/extension/shared/i18n.js
+++ b/extension/shared/i18n.js
@@ -64,7 +64,9 @@ const translations = {
           roles: 'Roles:',
           did: 'DID:',
           username: 'Username:',
-          domain: 'Trusted domain:'
+          domain: 'Trusted domain:',
+          verificationMethod: 'Verification method:',
+          keyType: 'Key type:'
         },
         authorizedSites: 'Authorized sites',
         lastUsed: 'Last used:',
@@ -180,17 +182,27 @@ const translations = {
       },
       overlay: {
         title: 'SDID login request',
-        origin: 'Origin:',
+        subtitle: 'Review and approve this sign-in request.',
+        origin: 'Origin',
         chooseIdentity: 'Choose identity',
         remember: 'Remember this site for one-click approvals',
         rememberAuthorized: 'This site is already authorized. Uncheck to require approval next time.',
         rememberHint: 'Keep this checked to approve future logins instantly.',
-        summaryIdentity: 'Identity:',
-        summaryDid: 'DID:',
-        summaryRoles: 'Roles:',
-        summaryDomain: 'Trusted domain:',
-        summaryUsername: 'Username:',
-        summaryNotes: 'Notes:'
+        sectionRequest: 'Request details',
+        sectionIdentity: 'Identity preview',
+        summarySite: 'Site',
+        summaryTime: 'Requested at',
+        summaryRequestId: 'Request ID',
+        summaryChallenge: 'Challenge nonce',
+        summaryIdentity: 'Identity',
+        summaryDid: 'DID',
+        summaryVerification: 'Verification method',
+        summaryKeyType: 'Key type',
+        summaryRoles: 'Roles',
+        summaryDomain: 'Trusted domain',
+        summaryUsername: 'Username',
+        summaryNotes: 'Notes',
+        summaryTags: 'Tags'
       }
     }
   },
@@ -255,7 +267,9 @@ const translations = {
           roles: '角色：',
           did: 'DID：',
           username: '用户名：',
-          domain: '信任域名：'
+          domain: '信任域名：',
+          verificationMethod: '验证方法：',
+          keyType: '密钥类型：'
         },
         authorizedSites: '已授权站点',
         lastUsed: '最近使用：',
@@ -371,17 +385,27 @@ const translations = {
       },
       overlay: {
         title: 'SDID 登录请求',
-        origin: '请求来源：',
+        subtitle: '请确认并签署本次登录请求。',
+        origin: '请求站点',
         chooseIdentity: '选择登录身份',
         remember: '记住此站点，下次一键授权',
         rememberAuthorized: '当前站点已授权，取消勾选则下次重新确认。',
         rememberHint: '保持勾选以便下次自动快速授权。',
-        summaryIdentity: '身份：',
-        summaryDid: 'DID：',
-        summaryRoles: '角色：',
-        summaryDomain: '信任域名：',
-        summaryUsername: '用户名：',
-        summaryNotes: '备注：'
+        sectionRequest: '请求信息',
+        sectionIdentity: '身份预览',
+        summarySite: '站点',
+        summaryTime: '请求时间',
+        summaryRequestId: '请求 ID',
+        summaryChallenge: '随机挑战值',
+        summaryIdentity: '身份',
+        summaryDid: 'DID',
+        summaryVerification: '验证方法',
+        summaryKeyType: '密钥类型',
+        summaryRoles: '角色',
+        summaryDomain: '信任域名',
+        summaryUsername: '用户名',
+        summaryNotes: '备注',
+        summaryTags: '标签'
       }
     }
   }


### PR DESCRIPTION
## Summary
- return canonical DID-auth payloads with proof metadata, DID document details, and richer request context in the approval overlay
- surface verification method and key type in the management UI with matching i18n strings
- update the demo verifier and README to validate the new canonical request flow

## Testing
- Not run (extension and documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d3cfd489ec83298f9e86fe35706e6f