### PR TITLE
Add administrator approval workflow to demo

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -5,9 +5,14 @@ const identityElement = document.getElementById('identity');
 const verificationElement = document.getElementById('verification');
 const languageToggle = document.getElementById('language-toggle');
 const languageButtons = languageToggle ? Array.from(languageToggle.querySelectorAll('button')) : [];
+const approvalStatusElement = document.getElementById('approval-status');
+const approvalListElement = document.getElementById('approval-list');
+const submitApprovalButton = document.getElementById('submit-approval');
+const approvalActionsElement = document.getElementById('approval-actions');
 
 const LANGUAGE_STORAGE_KEY = 'sdid-demo-language';
 const SUPPORTED_LANGUAGES = ['en', 'zh'];
+const APPROVAL_STORAGE_KEY = 'sdid-demo-approvals';
 
 const translations = {
   en: {
@@ -52,6 +57,52 @@ const translations = {
       failure: 'Signature verification failed.',
       error: 'Unable to verify the signature. Check the console for details.',
       mismatch: 'Authentication payload mismatch.'
+    },
+    approvals: {
+      title: 'Identity approvals',
+      status: {
+        disconnected: 'Connect with SDID to manage identity approvals.',
+        admin: 'Signed in as administrator {label}. Review pending requests below.',
+        notSubmitted: 'No approval request has been submitted for this identity.',
+        pending: 'Approval submitted on {date}. Waiting for an administrator signature.',
+        approved: 'Certified on {date} by {approver}.'
+      },
+      actions: {
+        submit: 'Submit approval request',
+        approve: 'Approve',
+        approving: 'Requesting administrator signature…',
+        approved: '{label} approved successfully.',
+        submitted: 'Approval request submitted for {label}.',
+        error: 'Unable to complete the approval.'
+      },
+      list: {
+        headerApplicant: 'Applicant',
+        headerRoles: 'Roles',
+        headerCreated: 'Submitted',
+        headerStatus: 'Status',
+        headerActions: 'Actions',
+        statusPending: 'Pending',
+        statusApproved: 'Approved',
+        empty: 'No approval requests yet.'
+      },
+      prompts: {
+        approveMessage: 'Approve identity {label}'
+      },
+      errors: {
+        submissionUnavailable: 'Connect with SDID before submitting an approval request.',
+        alreadySubmitted: 'An approval request has already been submitted for this identity.',
+        adminOnly: 'Administrator approval is required.'
+      },
+      verification: {
+        pending: 'Identity approval is still pending administrator review.',
+        missing: 'Identity has not been approved by an administrator.',
+        adminOnly: 'Administrator approval signature required.'
+      },
+      card: {
+        submitted: 'Submitted: {date}',
+        approved: 'Approved: {date}',
+        approver: 'Approved by {approver}'
+      }
     },
     login: {
       message: 'Demo dApp requests access'
@@ -102,6 +153,52 @@ const translations = {
       error: '无法验证签名，请查看控制台日志。',
       mismatch: '认证负载不一致。'
     },
+    approvals: {
+      title: '身份审批',
+      status: {
+        disconnected: '请先连接 SDID 以管理身份审批。',
+        admin: '已使用管理员身份 {label} 登录，可在下方审批待处理请求。',
+        notSubmitted: '当前身份尚未提交审批请求。',
+        pending: '已于 {date} 提交审批，等待管理员签名。',
+        approved: '已于 {date} 由 {approver} 完成认证。'
+      },
+      actions: {
+        submit: '提交审批请求',
+        approve: '签名审批',
+        approving: '正在请求管理员签名…',
+        approved: '{label} 已通过审批。',
+        submitted: '已为 {label} 提交审批请求。',
+        error: '审批流程未能完成。'
+      },
+      list: {
+        headerApplicant: '申请人',
+        headerRoles: '角色',
+        headerCreated: '提交时间',
+        headerStatus: '状态',
+        headerActions: '操作',
+        statusPending: '待审批',
+        statusApproved: '已通过',
+        empty: '暂无审批请求。'
+      },
+      prompts: {
+        approveMessage: '审批身份 {label}'
+      },
+      errors: {
+        submissionUnavailable: '请先连接 SDID 再提交审批请求。',
+        alreadySubmitted: '当前身份已提交审批请求。',
+        adminOnly: '需要管理员身份才能执行审批。'
+      },
+      verification: {
+        pending: '身份审批仍在等待管理员审核。',
+        missing: '该身份尚未获得管理员认证。',
+        adminOnly: '必须由管理员签名确认审批。'
+      },
+      card: {
+        submitted: '提交时间：{date}',
+        approved: '通过时间：{date}',
+        approver: '审批人：{approver}'
+      }
+    },
     login: {
       message: '演示应用请求访问'
     },
@@ -114,6 +211,9 @@ const translations = {
 let currentLanguage = 'en';
 let lastStatus = { key: null, replacements: null, message: '', tone: 'info' };
 let lastVerification = null;
+let approvalsState = loadApprovals();
+let currentIdentityResponse = null;
+let lastCertification = { status: 'disconnected', approval: null };
 
 function sanitizeLanguage(value) {
   return SUPPORTED_LANGUAGES.includes(value) ? value : 'en';
@@ -171,6 +271,382 @@ function translate(key, replacements = {}, language = currentLanguage) {
     return key;
   }
   return formatTemplate(template, replacements);
+}
+
+function normalizeRoles(roles) {
+  if (!Array.isArray(roles)) {
+    return [];
+  }
+  return roles
+    .map((role) => (typeof role === 'string' ? role.trim() : ''))
+    .filter(Boolean);
+}
+
+function isAdminIdentity(identity) {
+  if (!identity) {
+    return false;
+  }
+  return normalizeRoles(identity.roles).some((role) => role.toLowerCase() === 'admin');
+}
+
+function normalizeApprovalRecord(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const id = typeof raw.id === 'string' ? raw.id : null;
+  const applicantDid = typeof raw.applicantDid === 'string' ? raw.applicantDid : null;
+  if (!id || !applicantDid) {
+    return null;
+  }
+  return {
+    id,
+    applicantDid,
+    applicantLabel: typeof raw.applicantLabel === 'string' ? raw.applicantLabel : '',
+    applicantRoles: normalizeRoles(raw.applicantRoles || raw.roles),
+    createdAt: typeof raw.createdAt === 'string' ? raw.createdAt : new Date().toISOString(),
+    status: raw.status === 'approved' ? 'approved' : 'pending',
+    approvedAt: typeof raw.approvedAt === 'string' ? raw.approvedAt : null,
+    approverDid: typeof raw.approverDid === 'string' ? raw.approverDid : null,
+    approverLabel: typeof raw.approverLabel === 'string' ? raw.approverLabel : null,
+    approverRoles: normalizeRoles(raw.approverRoles),
+    approvalChallenge: typeof raw.approvalChallenge === 'string' ? raw.approvalChallenge : null,
+    approvalSignature: typeof raw.approvalSignature === 'string' ? raw.approvalSignature : null
+  };
+}
+
+function loadApprovals() {
+  let raw = null;
+  try {
+    raw = localStorage.getItem(APPROVAL_STORAGE_KEY);
+  } catch (_error) {
+    raw = null;
+  }
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed
+      .map((item) => normalizeApprovalRecord(item))
+      .filter((item) => item !== null);
+  } catch (_error) {
+    return [];
+  }
+}
+
+function saveApprovals(list) {
+  try {
+    localStorage.setItem(APPROVAL_STORAGE_KEY, JSON.stringify(list));
+  } catch (error) {
+    console.warn('Unable to persist approvals', error);
+  }
+}
+
+function updateApprovals(nextList) {
+  approvalsState = Array.isArray(nextList) ? nextList : [];
+  saveApprovals(approvalsState);
+  renderApprovalUI();
+}
+
+function generateApprovalId() {
+  const randomValue = crypto.getRandomValues(new Uint32Array(1))[0].toString(16);
+  return `approval-${Date.now().toString(16)}-${randomValue}`;
+}
+
+function getCertificationState(identity) {
+  if (!identity || !identity.did) {
+    return { status: 'disconnected', approval: null };
+  }
+  if (isAdminIdentity(identity)) {
+    return { status: 'admin', approval: null };
+  }
+  const matches = approvalsState.filter((item) => item.applicantDid === identity.did);
+  if (!matches.length) {
+    return { status: 'missing', approval: null };
+  }
+  const approved = matches
+    .filter((item) => item.status === 'approved')
+    .sort((a, b) => {
+      const aTime = Date.parse(a.approvedAt || a.createdAt || 0);
+      const bTime = Date.parse(b.approvedAt || b.createdAt || 0);
+      return bTime - aTime;
+    })[0];
+  if (approved) {
+    return { status: 'approved', approval: approved };
+  }
+  const pending = matches
+    .filter((item) => item.status !== 'approved')
+    .sort((a, b) => Date.parse(b.createdAt || 0) - Date.parse(a.createdAt || 0))[0];
+  if (pending) {
+    return { status: 'pending', approval: pending };
+  }
+  return { status: 'missing', approval: null };
+}
+
+function formatRolesList(roles) {
+  const normalized = normalizeRoles(roles);
+  return normalized.length ? normalized.join(', ') : '—';
+}
+
+function formatTimestamp(value) {
+  if (!value) {
+    return '—';
+  }
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '—';
+    }
+    const locale = currentLanguage === 'zh' ? 'zh-CN' : 'en-US';
+    const formatter = new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' });
+    return formatter.format(date);
+  } catch (_error) {
+    return '—';
+  }
+}
+
+function formatApplicantLabel(request) {
+  const label = (request?.applicantLabel || '').trim();
+  const did = request?.applicantDid || '';
+  if (label && did && label !== did) {
+    return `${label} (${did})`;
+  }
+  return label || did || translate('labels.unknownIdentity');
+}
+
+function formatApproverName(request) {
+  const label = (request?.approverLabel || '').trim();
+  if (label) {
+    return label;
+  }
+  return request?.approverDid || translate('labels.unknownIdentity');
+}
+
+function createApplicantCard(request) {
+  const card = document.createElement('div');
+  card.className = 'approval-card';
+
+  const title = document.createElement('strong');
+  title.textContent = formatApplicantLabel(request);
+  card.appendChild(title);
+
+  if (
+    request.applicantLabel &&
+    request.applicantDid &&
+    request.applicantLabel.trim() &&
+    request.applicantLabel.trim() !== request.applicantDid
+  ) {
+    const didLine = document.createElement('small');
+    didLine.textContent = request.applicantDid;
+    card.appendChild(didLine);
+  }
+
+  const rolesLine = document.createElement('span');
+  rolesLine.textContent = `${translate('approvals.list.headerRoles')}: ${formatRolesList(
+    request.applicantRoles
+  )}`;
+  card.appendChild(rolesLine);
+
+  const submittedLine = document.createElement('span');
+  submittedLine.textContent = translate('approvals.card.submitted', {
+    date: formatTimestamp(request.createdAt)
+  });
+  card.appendChild(submittedLine);
+
+  const statusLine = document.createElement('span');
+  const statusKey = request.status === 'approved' ? 'approvals.list.statusApproved' : 'approvals.list.statusPending';
+  statusLine.textContent = `${translate('approvals.list.headerStatus')}: ${translate(statusKey)}`;
+  card.appendChild(statusLine);
+
+  if (request.status === 'approved') {
+    const approvedLine = document.createElement('span');
+    approvedLine.textContent = translate('approvals.card.approved', {
+      date: formatTimestamp(request.approvedAt || request.createdAt)
+    });
+    card.appendChild(approvedLine);
+
+    const approverLine = document.createElement('span');
+    approverLine.textContent = translate('approvals.card.approver', {
+      approver: formatApproverName(request)
+    });
+    card.appendChild(approverLine);
+  }
+
+  return card;
+}
+
+function renderAdminApprovalList() {
+  if (!approvalListElement) {
+    return;
+  }
+  approvalListElement.innerHTML = '';
+  const sorted = [...approvalsState].sort((a, b) => {
+    if (a.status === b.status) {
+      return Date.parse(b.createdAt || 0) - Date.parse(a.createdAt || 0);
+    }
+    return a.status === 'pending' ? -1 : 1;
+  });
+  if (!sorted.length) {
+    const emptyMessage = document.createElement('p');
+    emptyMessage.textContent = translate('approvals.list.empty');
+    approvalListElement.appendChild(emptyMessage);
+    return;
+  }
+
+  const table = document.createElement('table');
+  table.className = 'approval-table';
+
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  ['headerApplicant', 'headerRoles', 'headerCreated', 'headerStatus', 'headerActions'].forEach((key) => {
+    const th = document.createElement('th');
+    th.textContent = translate(`approvals.list.${key}`);
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  sorted.forEach((request) => {
+    const row = document.createElement('tr');
+
+    const applicantCell = document.createElement('td');
+    const label = (request.applicantLabel || '').trim();
+    if (label && request.applicantDid && label !== request.applicantDid) {
+      const strong = document.createElement('strong');
+      strong.textContent = label;
+      applicantCell.appendChild(strong);
+
+      const didLine = document.createElement('div');
+      didLine.className = 'muted';
+      didLine.textContent = request.applicantDid;
+      applicantCell.appendChild(didLine);
+    } else {
+      applicantCell.textContent = request.applicantDid || label || translate('labels.unknownIdentity');
+    }
+    row.appendChild(applicantCell);
+
+    const rolesCell = document.createElement('td');
+    rolesCell.textContent = formatRolesList(request.applicantRoles);
+    row.appendChild(rolesCell);
+
+    const createdCell = document.createElement('td');
+    createdCell.textContent = formatTimestamp(request.createdAt);
+    row.appendChild(createdCell);
+
+    const statusCell = document.createElement('td');
+    const statusKey = request.status === 'approved' ? 'approvals.list.statusApproved' : 'approvals.list.statusPending';
+    statusCell.textContent = translate(statusKey);
+    row.appendChild(statusCell);
+
+    const actionsCell = document.createElement('td');
+    actionsCell.className = 'actions';
+    if (request.status === 'pending') {
+      const approveButton = document.createElement('button');
+      approveButton.type = 'button';
+      approveButton.textContent = translate('approvals.actions.approve');
+      approveButton.dataset.requestId = request.id;
+      actionsCell.appendChild(approveButton);
+    } else {
+      actionsCell.textContent = '—';
+    }
+    row.appendChild(actionsCell);
+
+    tbody.appendChild(row);
+  });
+  table.appendChild(tbody);
+  approvalListElement.appendChild(table);
+}
+
+function renderApprovalUI() {
+  if (!approvalStatusElement || !approvalListElement) {
+    return;
+  }
+
+  const identity = currentIdentityResponse?.identity || null;
+  const certification = getCertificationState(identity);
+  lastCertification = certification;
+
+  approvalListElement.innerHTML = '';
+
+  if (approvalActionsElement) {
+    approvalActionsElement.hidden = true;
+  }
+  if (submitApprovalButton) {
+    submitApprovalButton.disabled = true;
+  }
+
+  if (!identity) {
+    approvalStatusElement.textContent = translate('approvals.status.disconnected');
+    return;
+  }
+
+  const label =
+    (identity.label && identity.label.trim()) || identity.did || translate('labels.unknownIdentity');
+
+  if (certification.status === 'admin') {
+    approvalStatusElement.textContent = translate('approvals.status.admin', { label });
+    renderAdminApprovalList();
+    return;
+  }
+
+  if (certification.status === 'missing' && approvalActionsElement && submitApprovalButton) {
+    approvalActionsElement.hidden = false;
+    submitApprovalButton.disabled = false;
+  }
+
+  if (certification.status === 'missing') {
+    approvalStatusElement.textContent = translate('approvals.status.notSubmitted');
+    return;
+  }
+
+  if (certification.status === 'pending') {
+    const date = formatTimestamp(certification.approval?.createdAt);
+    approvalStatusElement.textContent = translate('approvals.status.pending', { date });
+    if (certification.approval) {
+      approvalListElement.appendChild(createApplicantCard(certification.approval));
+    }
+    return;
+  }
+
+  if (certification.status === 'approved') {
+    const date = formatTimestamp(certification.approval?.approvedAt || certification.approval?.createdAt);
+    const approver = formatApproverName(certification.approval);
+    approvalStatusElement.textContent = translate('approvals.status.approved', { date, approver });
+    if (certification.approval) {
+      approvalListElement.appendChild(createApplicantCard(certification.approval));
+    }
+    return;
+  }
+
+  approvalStatusElement.textContent = translate('approvals.status.notSubmitted');
+}
+
+function enforceCertification(response, verification) {
+  const identity = response?.identity || null;
+  const certification = getCertificationState(identity);
+  lastCertification = certification;
+
+  if (!identity) {
+    return verification;
+  }
+
+  if (!verification?.verified) {
+    return verification;
+  }
+
+  if (certification.status === 'admin' || certification.status === 'approved') {
+    return verification;
+  }
+
+  if (certification.status === 'pending') {
+    return { verified: false, key: 'approvals.verification.pending' };
+  }
+
+  return { verified: false, key: 'approvals.verification.missing' };
 }
 
 function applyTranslations(root = document) {
@@ -380,6 +856,145 @@ async function verifyAuthenticationResponse(response) {
   }
 }
 
+function handleSubmitApproval() {
+  const identity = currentIdentityResponse?.identity || null;
+  if (!identity?.did) {
+    setStatusFromKey('approvals.errors.submissionUnavailable', {}, 'error');
+    return;
+  }
+  if (isAdminIdentity(identity)) {
+    setStatusFromKey('approvals.errors.alreadySubmitted', {}, 'info');
+    return;
+  }
+  const certification = getCertificationState(identity);
+  if (certification.status !== 'missing') {
+    setStatusFromKey('approvals.errors.alreadySubmitted', {}, 'info');
+    return;
+  }
+
+  const label =
+    (identity.label && identity.label.trim()) || identity.did || translate('labels.unknownIdentity');
+  const request = {
+    id: generateApprovalId(),
+    applicantDid: identity.did,
+    applicantLabel: identity.label || '',
+    applicantRoles: normalizeRoles(identity.roles),
+    createdAt: new Date().toISOString(),
+    status: 'pending',
+    approvedAt: null,
+    approverDid: null,
+    approverLabel: null,
+    approverRoles: []
+  };
+
+  updateApprovals([...approvalsState, request]);
+  setVerification({ verified: false, key: 'approvals.verification.pending' });
+  setStatusFromKey('approvals.actions.submitted', { label }, 'success');
+}
+
+async function handleApproveRequest(requestId, triggerButton) {
+  if (!requestId) {
+    return;
+  }
+
+  const request = approvalsState.find((item) => item.id === requestId);
+  if (!request || request.status === 'approved') {
+    return;
+  }
+
+  const identity = currentIdentityResponse?.identity || null;
+  if (!identity || !isAdminIdentity(identity)) {
+    setStatusFromKey('approvals.errors.adminOnly', {}, 'error');
+    return;
+  }
+
+  const previousIdentityResponse = currentIdentityResponse;
+  const button = triggerButton instanceof HTMLButtonElement ? triggerButton : null;
+  if (button) {
+    button.disabled = true;
+  }
+  disableButtons(true);
+  setStatusFromKey('approvals.actions.approving');
+
+  try {
+    const sdid = await waitForSdid();
+    const payload = {
+      type: 'sdid-demo-approval',
+      requestId: request.id,
+      applicantDid: request.applicantDid,
+      applicantLabel: request.applicantLabel,
+      applicantRoles: normalizeRoles(request.applicantRoles),
+      createdAt: request.createdAt
+    };
+    const challenge = canonicalizeJson(payload);
+    const message = translate('approvals.prompts.approveMessage', {
+      label: request.applicantLabel || request.applicantDid
+    });
+
+    const response = await sdid.requestLogin({
+      message,
+      challenge,
+      forcePrompt: true
+    });
+
+    currentIdentityResponse = response;
+    renderIdentity(response);
+    renderApprovalUI();
+
+    const verification = await verifyAuthenticationResponse(response);
+    if (!verification.verified) {
+      setVerification(verification);
+      setStatusFromKey('approvals.actions.error', {}, 'error');
+      currentIdentityResponse = previousIdentityResponse;
+      renderIdentity(previousIdentityResponse);
+      renderApprovalUI();
+      return;
+    }
+    if (!isAdminIdentity(response.identity)) {
+      setVerification({ verified: false, key: 'approvals.verification.adminOnly' });
+      setStatusFromKey('approvals.errors.adminOnly', {}, 'error');
+      currentIdentityResponse = previousIdentityResponse;
+      renderIdentity(previousIdentityResponse);
+      renderApprovalUI();
+      return;
+    }
+
+    const approvedRequest = {
+      ...request,
+      status: 'approved',
+      approvedAt: new Date().toISOString(),
+      approverDid: response.identity.did,
+      approverLabel: response.identity.label || '',
+      approverRoles: normalizeRoles(response.identity.roles),
+      approvalChallenge: challenge,
+      approvalSignature: response.signature || response?.proof?.signatureValue || null
+    };
+
+    updateApprovals(
+      approvalsState.map((item) => (item.id === request.id ? approvedRequest : item))
+    );
+
+    const adjustedVerification = enforceCertification(response, verification);
+    setVerification(adjustedVerification);
+
+    const label =
+      request.applicantLabel?.trim() || request.applicantDid || translate('labels.unknownIdentity');
+    setStatusFromKey('approvals.actions.approved', { label }, 'success');
+  } catch (error) {
+    console.error('Admin approval failed', error);
+    setStatusFromKey('approvals.actions.error', {}, 'error');
+    currentIdentityResponse = previousIdentityResponse;
+    renderIdentity(previousIdentityResponse);
+    renderApprovalUI();
+  } finally {
+    disableButtons(false);
+    if (button) {
+      const latest = approvalsState.find((item) => item.id === requestId);
+      button.disabled = !latest || latest.status !== 'pending';
+    }
+  }
+}
+
 function initializeLanguage() {
   let stored = null;
   try {
@@ -393,6 +1008,7 @@ function initializeLanguage() {
   updateLanguageToggleUI(currentLanguage);
   applyStatus();
   applyVerification();
+  renderApprovalUI();
 }
 
 function changeLanguage(language) {
@@ -412,12 +1028,16 @@ function changeLanguage(language) {
   updateLanguageToggleUI(currentLanguage);
   applyStatus();
   applyVerification();
+  renderApprovalUI();
 }
 
 async function requestLogin(forcePrompt = true) {
   disableButtons(true);
   setVerification(null);
   renderIdentity(null);
+  currentIdentityResponse = null;
+  lastCertification = { status: 'disconnected', approval: null };
+  renderApprovalUI();
   setStatusFromKey('status.connecting');
   try {
     const sdid = await waitForSdid();
@@ -427,16 +1047,22 @@ async function requestLogin(forcePrompt = true) {
       challenge,
       forcePrompt
     });
+    currentIdentityResponse = response;
     renderIdentity(response);
     const verification = await verifyAuthenticationResponse(response);
-    setVerification(verification);
+    const adjustedVerification = enforceCertification(response, verification);
+    setVerification(adjustedVerification);
     const label = (response.identity?.label && response.identity.label.trim())
       || response.identity?.did
       || translate('labels.unknownIdentity');
-    const tone = verification.verified ? 'success' : 'info';
+    const tone = adjustedVerification.verified ? 'success' : 'info';
     setStatusFromKey('status.connected', { label }, tone);
+    renderApprovalUI();
   } catch (error) {
     console.error('Demo login failed', error);
+    currentIdentityResponse = null;
+    lastCertification = { status: 'disconnected', approval: null };
+    renderApprovalUI();
     const rawMessage = typeof error?.message === 'string' ? error.message.trim() : '';
     if (rawMessage) {
       const normalized = rawMessage.toLowerCase();
@@ -476,6 +1102,30 @@ if (connectButton) {
 
 if (forceButton) {
   forceButton.addEventListener('click', () => requestLogin(true));
+}
+
+if (submitApprovalButton) {
+  submitApprovalButton.addEventListener('click', () => {
+    handleSubmitApproval();
+  });
+}
+
+if (approvalListElement) {
+  approvalListElement.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+    const button = target.closest('button[data-request-id]');
+    if (!button) {
+      return;
+    }
+    event.preventDefault();
+    const requestId = button.dataset.requestId;
+    if (requestId) {
+      handleApproveRequest(requestId, button);
+    }
+  });
 }
 
 if (!window.SDID?.requestLogin) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -64,6 +64,21 @@
         <h2 data-i18n="sections.verification"></h2>
         <div id="verification" class="verification"></div>
       </section>
+
+      <section class="card" id="approvals-card">
+        <h2 data-i18n="approvals.title"></h2>
+        <p id="approval-status" class="approval-status"></p>
+        <div class="approval-actions" id="approval-actions" hidden>
+          <button
+            id="submit-approval"
+            class="primary"
+            data-i18n="approvals.actions.submit"
+            data-i18n-target="text,aria-label"
+            type="button"
+          ></button>
+        </div>
+        <div id="approval-list" class="approval-list"></div>
+      </section>
     </main>
 
     <footer class="footer">

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -233,6 +233,90 @@ pre {
   color: #c4554a;
 }
 
+.approval-status {
+  margin: 0;
+  color: #63584c;
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.approval-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.approval-actions[hidden] {
+  display: none;
+}
+
+.approval-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.approval-card {
+  border: 1px solid #ece2d5;
+  border-radius: 14px;
+  padding: 16px;
+  background: #faf7f2;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.9rem;
+  color: #63584c;
+}
+
+.approval-card strong {
+  color: #241c14;
+}
+
+.approval-card small {
+  color: #968b7d;
+}
+
+.approval-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  color: #63584c;
+}
+
+.approval-table thead {
+  background: rgba(244, 242, 238, 0.9);
+}
+
+.approval-table th,
+.approval-table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid #ece2d5;
+  vertical-align: top;
+}
+
+.approval-table th {
+  font-weight: 600;
+  color: #241c14;
+}
+
+.approval-table td.actions {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.approval-table tr:last-child td {
+  border-bottom: none;
+}
+
+.approval-table .muted {
+  display: block;
+  color: #968b7d;
+  font-size: 0.8rem;
+  margin-top: 4px;
+}
+
 .footer {
   margin-top: auto;
   padding: 24px;


### PR DESCRIPTION
## Summary
- add an approval management card to the demo so identities can request certification and administrators can sign approvals with the SDID extension
- persist approval requests in local storage, require an approved identity before treating signatures as verified, and surface new localization strings for the flow
- style the new approval UI elements for both applicant and administrator views

## Testing
- not run (demo-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d888309f4c8329bcbd8c78bf48e355