### PR TITLE
Handle insecure demo verification contexts

### DIFF
--- a/demo/styles.css
+++ b/demo/styles.css
@@ -205,6 +205,10 @@ button:disabled {
   color: #c4554a;
 }
 
+.status[data-state='warning'] {
+  color: #c27d1a;
+}
+
 .status[data-state='info'] {
   color: #63584c;
 }
@@ -238,6 +242,10 @@ pre {
 
 .verification .error {
   color: #c4554a;
+}
+
+.verification .warning {
+  color: #c27d1a;
 }
 
 .approval-status {


### PR DESCRIPTION
## Summary
- allow the demo to surface a clear warning when signatures cannot be verified because SubtleCrypto is unavailable
- treat insecure origins as a non-blocking condition during admin approvals while updating status styling for warning states

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddcb119ab0832980bfc6969241ff48