### PR TITLE
Trust insecure contexts and surface pending approvals

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -57,7 +57,9 @@ const translations = {
       success: 'Signature verified successfully.',
       failure: 'Signature verification failed.',
       error: 'Unable to verify the signature. Check the console for details.',
-      mismatch: 'Authentication payload mismatch.'
+      mismatch: 'Authentication payload mismatch.',
+      insecureContext:
+        'This page is running on an insecure origin, so the browser cannot verify signatures locally. The response has been trusted automatically.'
     },
     approvals: {
       title: 'Identity approvals',
@@ -152,7 +154,8 @@ const translations = {
       success: '签名验证通过。',
       failure: '签名验证失败。',
       error: '无法验证签名，请查看控制台日志。',
-      mismatch: '认证负载不一致。'
+      mismatch: '认证负载不一致。',
+      insecureContext: '当前页面非安全来源，浏览器无法在本地验证签名，系统已默认信任该响应。'
     },
     approvals: {
       title: '身份审批',
@@ -722,7 +725,8 @@ function applyStatus() {
   const { key, replacements, message, tone } = lastStatus;
   const text = key ? translate(key, replacements) : message || '';
   statusElement.textContent = text;
-  const state = tone === 'success' ? 'success' : tone === 'error' ? 'error' : 'info';
+  const state =
+    tone === 'success' ? 'success' : tone === 'error' ? 'error' : tone === 'warning' ? 'warning' : 'info';
   statusElement.dataset.state = state;
 }
 
@@ -744,14 +748,15 @@ function applyVerification() {
   if (!lastVerification) {
     return;
   }
-  const { key, replacements, message, verified } = lastVerification;
+  const { key, replacements, message, verified, severity } = lastVerification;
   const text = key ? translate(key, replacements) : message || '';
   if (!text) {
     return;
   }
   const paragraph = document.createElement('p');
   paragraph.textContent = text;
-  paragraph.className = verified ? 'success' : 'error';
+  const cssClass = severity || (verified ? 'success' : 'error');
+  paragraph.className = cssClass;
   verificationElement.appendChild(paragraph);
 }
 
@@ -764,11 +769,13 @@ function setVerification(result) {
     applyVerification();
     return;
   }
+  const severity = result.severity || (result.verified ? 'success' : 'error');
   lastVerification = {
     key: result.key || null,
     replacements: result.replacements || null,
     message: result.message || '',
-    verified: Boolean(result.verified)
+    verified: Boolean(result.verified),
+    severity
   };
   applyVerification();
 }
@@ -832,8 +839,14 @@ function createChallenge() {
   return `demo:${Date.now().toString(16)}:${crypto.getRandomValues(new Uint32Array(1))[0].toString(16)}`;
 }
 
-async function verifySignatureWithKey(publicKeyJwk, data, signature) {
-  const publicKey = await crypto.subtle.importKey(
+async function verifySignatureWithKey(publicKeyJwk, data, signature, subtleCrypto) {
+  const subtle =
+    subtleCrypto || (globalThis.crypto?.subtle || globalThis.crypto?.webkitSubtle || null);
+  if (!subtle || typeof subtle.importKey !== 'function' || typeof subtle.verify !== 'function') {
+    throw new Error('SubtleCrypto unavailable');
+  }
+
+  const publicKey = await subtle.importKey(
     'jwk',
     publicKeyJwk,
     { name: 'ECDSA', namedCurve: 'P-256' },
@@ -846,7 +859,7 @@ async function verifySignatureWithKey(publicKeyJwk, data, signature) {
     bytes[i] = binary.charCodeAt(i);
   }
   const dataBytes = new TextEncoder().encode(data);
-  return crypto.subtle.verify({ name: 'ECDSA', hash: { name: 'SHA-256' } }, publicKey, bytes, dataBytes);
+  return subtle.verify({ name: 'ECDSA', hash: { name: 'SHA-256' } }, publicKey, bytes, dataBytes);
 }
 
 async function verifyAuthenticationResponse(response) {
@@ -877,11 +890,36 @@ async function verifyAuthenticationResponse(response) {
     return { verified: false, key: 'verification.missing' };
   }
 
+  const subtle = globalThis.crypto?.subtle || globalThis.crypto?.webkitSubtle || null;
+  if (!subtle || typeof subtle.importKey !== 'function' || typeof subtle.verify !== 'function') {
+    return {
+      verified: true,
+      key: 'verification.insecureContext',
+      severity: 'info',
+      reason: 'unavailable',
+      skipped: true
+    };
+  }
+
   try {
-    const verified = await verifySignatureWithKey(identity.publicKeyJwk, dataToVerify, signature);
+    const verified = await verifySignatureWithKey(
+      identity.publicKeyJwk,
+      dataToVerify,
+      signature,
+      subtle
+    );
     return { verified, key: verified ? 'verification.success' : 'verification.failure' };
   } catch (error) {
     console.error('Signature verification error', error);
+    if (typeof error?.message === 'string' && error.message.includes('SubtleCrypto unavailable')) {
+      return {
+        verified: true,
+        key: 'verification.insecureContext',
+        severity: 'info',
+        reason: 'unavailable',
+        skipped: true
+      };
+    }
     return { verified: false, key: 'verification.error' };
   }
 }
@@ -920,6 +958,7 @@ function handleSubmitApproval() {
   updateApprovals([...approvalsState, request]);
   setVerification({ verified: false, key: 'approvals.verification.pending' });
   setStatusFromKey('approvals.actions.submitted', { label }, 'success');
+  renderApprovalUI();
 }
 
 async function handleApproveRequest(requestId, triggerButton) {
@@ -972,7 +1011,8 @@ async function handleApproveRequest(requestId, triggerButton) {
     renderApprovalUI();
 
     const verification = await verifyAuthenticationResponse(response);
-    if (!verification.verified) {
+    const verificationUnavailable = !verification.verified && verification.reason === 'unavailable';
+    if (!verification.verified && !verificationUnavailable) {
       setVerification(verification);
       setStatusFromKey('approvals.actions.error', {}, 'error');
       currentIdentityResponse = previousIdentityResponse;
@@ -1085,7 +1125,11 @@ async function requestLogin(forcePrompt = true) {
     const label = (response.identity?.label && response.identity.label.trim())
       || response.identity?.did
       || translate('labels.unknownIdentity');
-    const tone = adjustedVerification.verified ? 'success' : 'info';
+    const tone = adjustedVerification.verified
+      ? 'success'
+      : adjustedVerification.severity === 'warning'
+      ? 'warning'
+      : 'info';
     setStatusFromKey('status.connected', { label }, tone);
     renderApprovalUI();
   } catch (error) {

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -205,6 +205,10 @@ button:disabled {
   color: #c4554a;
 }
 
+.status[data-state='warning'] {
+  color: #c27d1a;
+}
+
 .status[data-state='info'] {
   color: #63584c;
 }
@@ -236,8 +240,16 @@ pre {
   color: #2f6d46;
 }
 
+.verification .info {
+  color: #63584c;
+}
+
 .verification .error {
   color: #c4554a;
+}
+
+.verification .warning {
+  color: #c27d1a;
 }
 
 .approval-status {


### PR DESCRIPTION
## Summary
- treat insecure demo contexts as automatically trusted and downgrade the verification banner tone
- update the insecure-context copy and styling so the informational state no longer looks like an error
- refresh the approvals panel immediately after submitting a request so the pending card always appears

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddcb119ab0832980bfc6969241ff48